### PR TITLE
add laptop/desktop header

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -69,6 +69,10 @@ const MainHeader = styled(MaxWidthWrapper)`
   justify-content: center;
   margin-top: 32px;
   margin-bottom: 48px;
+
+  @media (${QUERIES.tabletAndUp}) {
+    margin-bottom: 72px;
+  }
 `;
 
 export default Header;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -39,6 +39,10 @@ const SuperHeader = styled.div`
   padding: 16px 0;
   background: var(--color-gray-900);
   color: white;
+
+  @media (${QUERIES.laptopAndUp}) {
+    display: none;
+  }
 `;
 
 const Row = styled(MaxWidthWrapper)`

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -29,7 +29,25 @@ const Header = () => {
         </Row>
       </SuperHeader>
       <MainHeader>
+        <LargeScreenOnly>
+          <ActionGroup>
+            <button>
+              <Search size={24} />
+            </button>
+            <button>
+              <Menu size={24} />
+            </button>
+          </ActionGroup>
+        </LargeScreenOnly>
         <Logo />
+        <LargeScreenOnly>
+          <SubscribeWrapper>
+            <Button>Subscribe</Button>
+            <AlreadyASubscriberLink href="/">
+              Already a subscriber?
+            </AlreadyASubscriberLink>
+          </SubscribeWrapper>
+        </LargeScreenOnly>
       </MainHeader>
     </header>
   );
@@ -63,6 +81,14 @@ const ActionGroup = styled.div`
   }
 `;
 
+const LargeScreenOnly = styled.div`
+  display: none;
+
+  @media (${QUERIES.laptopAndUp}) {
+    display: revert;
+  }
+`;
+
 const MainHeader = styled(MaxWidthWrapper)`
   display: flex;
   align-items: center;
@@ -73,6 +99,25 @@ const MainHeader = styled(MaxWidthWrapper)`
   @media (${QUERIES.tabletAndUp}) {
     margin-bottom: 72px;
   }
+
+  @media (${QUERIES.laptopAndUp}) {
+    justify-content: space-between;
+  }
+`;
+
+const AlreadyASubscriberLink = styled.a`
+  font-size: 0.875rem;
+  text-decoration: underline;
+  font-weight: var(--font-weight-normal);
+  font-style: italic;
+  font-family: var(--font-family-serif);
+`;
+
+const SubscribeWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: center;
 `;
 
 export default Header;

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -2,6 +2,8 @@ import React from 'react';
 import styled from 'styled-components/macro';
 import format from 'date-fns/format';
 
+import { QUERIES } from '../../constants';
+
 const Logo = (props) => {
   return (
     <Wrapper>
@@ -22,6 +24,10 @@ const Wrapper = styled.div`
 const Link = styled.a`
   font-family: var(--font-family-logo);
   font-size: 3rem;
+
+  @media (${QUERIES.tabletAndUp}) {
+    font-size: 5.25rem;
+  }
 `;
 
 const TodaysDate = styled.p`


### PR DESCRIPTION
Submission for [Exercise 1: Header](https://github.com/VrsajkovIvan33/new-grid-times?tab=readme-ov-file#exercise-1-header).

- Hide `SuperHeader` on laptop and above.
- Add action group with icons + subscribe button for laptop and above on `MainHeader`.
- Increase bottom margin and logo font size for larger screens.