### PR TITLE
Main story grid

### DIFF
--- a/src/components/MainStoryGrid/MainStoryGrid.js
+++ b/src/components/MainStoryGrid/MainStoryGrid.js
@@ -12,6 +12,7 @@ import MainStory from '../MainStory';
 import SecondaryStory from '../SecondaryStory';
 import OpinionStory from '../OpinionStory';
 import Advertisement from '../Advertisement';
+import { QUERIES } from '../../constants';
 
 const MainStoryGrid = () => {
   return (
@@ -57,6 +58,21 @@ const Wrapper = styled.div`
     'advertisement';
   gap: 48px;
   margin-bottom: 48px;
+
+  @media(${QUERIES.tabletAndUp}) {
+    grid-template-columns: 2fr 1fr;
+    grid-template-areas:
+      'main-story secondary-stories'
+      'advertisement advertisement'
+      'opinion-stories opinion-stories';
+  }
+
+  @media(${QUERIES.laptopAndUp}) {
+    grid-template-columns: 5fr 4fr 3fr;
+    grid-template-areas:
+      'main-story secondary-stories opinion-stories'
+      'main-story advertisement advertisement';
+  }
 `;
 
 const MainStorySection = styled.section`

--- a/src/components/MainStoryGrid/MainStoryGrid.js
+++ b/src/components/MainStoryGrid/MainStoryGrid.js
@@ -99,9 +99,9 @@ const StoryWrapper = styled.div`
   }
 
   ${OpinionSection} & {
-    flex: 1;
-    
     @media(${QUERIES.tabletOnly}) {
+      flex: 1;
+
       &:not(:last-of-type) {
         border-bottom: revert;
         padding-bottom: revert;
@@ -116,8 +116,10 @@ const StoryList = styled.div`
   flex-direction: column;
 
   ${OpinionSection} & {
-    flex-direction: row;
-    gap: 32px;
+    @media(${QUERIES.tabletOnly}) {
+      flex-direction: row;
+      gap: 32px;
+    }
   }
 `;
 

--- a/src/components/MainStoryGrid/MainStoryGrid.js
+++ b/src/components/MainStoryGrid/MainStoryGrid.js
@@ -65,6 +65,9 @@ const Wrapper = styled.div`
       'main-story secondary-stories'
       'advertisement advertisement'
       'opinion-stories opinion-stories';
+    
+    // Replaced by grid dividers 
+    gap: 0;
   }
 
   @media(${QUERIES.laptopAndUp}) {
@@ -77,10 +80,22 @@ const Wrapper = styled.div`
 
 const MainStorySection = styled.section`
   grid-area: main-story;
+
+  @media(${QUERIES.tabletAndUp}) {
+    padding-right: 16px;
+    border-right: 1px solid var(--color-gray-300);
+    margin-right: 16px;
+  }
 `;
 
 const SecondaryStorySection = styled.section`
   grid-area: secondary-stories;
+
+  @media(${QUERIES.laptopAndUp}) {
+    padding-right: 16px;
+    border-right: 1px solid var(--color-gray-300);
+    margin-right: 16px;
+  }
 `;
 
 const OpinionSection = styled.section`
@@ -89,6 +104,16 @@ const OpinionSection = styled.section`
 
 const AdvertisementSection = styled.section`
   grid-area: advertisement;
+
+  @media(${QUERIES.tabletAndUp}) {
+    margin-top: 48px;
+  }
+
+  @media(${QUERIES.laptopAndUp}) {
+    padding-top: 16px;
+    border-top: 1px solid var(--color-gray-300);
+    margin-top: 16px;
+  }
 `;
 
 const StoryWrapper = styled.div`

--- a/src/components/MainStoryGrid/MainStoryGrid.js
+++ b/src/components/MainStoryGrid/MainStoryGrid.js
@@ -24,9 +24,9 @@ const MainStoryGrid = () => {
       <SecondaryStorySection>
         <StoryList>
           {SECONDARY_STORIES.map((story, index) => (
-            <VerticalStoryWrapper key={story.id}>
+            <StoryWrapper key={story.id}>
               <SecondaryStory {...story} />
-            </VerticalStoryWrapper>
+            </StoryWrapper>
           ))}
         </StoryList>
       </SecondaryStorySection>
@@ -35,9 +35,9 @@ const MainStoryGrid = () => {
         <SectionTitle>Opinion</SectionTitle>
         <StoryList>
           {OPINION_STORIES.map((story, index) => (
-            <VerticalStoryWrapper key={story.id}>
+            <StoryWrapper key={story.id}>
               <OpinionStory {...story} />
-            </VerticalStoryWrapper>
+            </StoryWrapper>
           ))}
         </StoryList>
       </OpinionSection>
@@ -83,25 +83,42 @@ const SecondaryStorySection = styled.section`
   grid-area: secondary-stories;
 `;
 
-const StoryList = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-const VerticalStoryWrapper = styled.div`
-  &:not(:last-of-type) {
-    border-bottom: 1px solid var(--color-gray-300);
-    padding-bottom: 16px;
-    margin-bottom: 16px;
-  }
-`;
-
 const OpinionSection = styled.section`
   grid-area: opinion-stories;
 `;
 
 const AdvertisementSection = styled.section`
   grid-area: advertisement;
+`;
+
+const StoryWrapper = styled.div`
+  &:not(:last-of-type) {
+    border-bottom: 1px solid var(--color-gray-300);
+    padding-bottom: 16px;
+    margin-bottom: 16px;
+  }
+
+  ${OpinionSection} & {
+    flex: 1;
+    
+    @media(${QUERIES.tabletOnly}) {
+      &:not(:last-of-type) {
+        border-bottom: revert;
+        padding-bottom: revert;
+        margin-bottom: revert;
+      }
+    }
+  }
+`;
+
+const StoryList = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  ${OpinionSection} & {
+    flex-direction: row;
+    gap: 32px;
+  }
 `;
 
 export default MainStoryGrid;

--- a/src/components/SecondaryStory/SecondaryStory.js
+++ b/src/components/SecondaryStory/SecondaryStory.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
+import { QUERIES } from '../../constants';
+
 const SecondaryStory = ({ id, title, image, location, abstract }) => {
   return (
     <a href={`/story/${id}`}>
@@ -21,6 +23,12 @@ const Wrapper = styled.article`
   gap: 4px 16px;
   grid-template-columns: 120px 1fr;
   color: var(--color-gray-900);
+
+  @media (${QUERIES.tabletOnly}) {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
 `;
 
 const Image = styled.img`


### PR DESCRIPTION
Submission for [Exercise 3: Main Story Grid](https://github.com/VrsajkovIvan33/new-grid-times?tab=readme-ov-file#exercise-3-main-story-grid).

- Customize main story grid structure for tablet and laptop+:
  - tablet: two columns, 2fr 1fr, and
  - laptop+: three columns, 5fr 4fr 3fr.
-  Responsive opinion stories structure for tablet only.
-  Responsive secondary stories structure for tablet only.
-  Add responsive grid dividers.