### PR TITLE
Specialty story grid

### DIFF
--- a/src/components/SpecialtyStoryGrid/SpecialtyStoryGrid.js
+++ b/src/components/SpecialtyStoryGrid/SpecialtyStoryGrid.js
@@ -52,9 +52,25 @@ const Wrapper = styled.div`
   display: grid;
   gap: 48px;
   grid-template-columns: minmax(0, 1fr);
+
+  @media (${QUERIES.tabletAndUp}) {
+    gap: 64;
+  }
+
+  @media (${QUERIES.laptopAndUp}) {
+    grid-template-columns: 1fr minmax(0, 1fr);
+    // Replaced by grid dividers
+    gap: 0;
+  }
 `;
 
-const MarketsSection = styled.section``;
+const MarketsSection = styled.section`
+  @media (${QUERIES.laptopAndUp}) {
+    border-right: 1px solid var(--color-gray-300);
+    padding-right: 16px;
+    margin-right: 16px;
+  }
+`;
 
 const MarketCards = styled.div`
   display: grid;

--- a/src/components/SpecialtyStoryGrid/SpecialtyStoryGrid.js
+++ b/src/components/SpecialtyStoryGrid/SpecialtyStoryGrid.js
@@ -51,10 +51,18 @@ const Wrapper = styled.div`
 
 const MarketsSection = styled.section``;
 
-const MarketCards = styled.div``;
+const MarketCards = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+`;
 
 const SportsSection = styled.section``;
 
-const SportsStories = styled.div``;
+const SportsStories = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 16px;
+`;
 
 export default SpecialtyStoryGrid;

--- a/src/components/SpecialtyStoryGrid/SpecialtyStoryGrid.js
+++ b/src/components/SpecialtyStoryGrid/SpecialtyStoryGrid.js
@@ -7,6 +7,8 @@ import MarketCard from '../MarketCard';
 import SectionTitle from '../SectionTitle';
 import MiniStory from '../MiniStory';
 
+import { QUERIES } from '../../constants';
+
 const SpecialtyStoryGrid = () => {
   return (
     <Wrapper>
@@ -36,7 +38,9 @@ const SpecialtyStoryGrid = () => {
         </SectionTitle>
         <SportsStories>
           {SPORTS_STORIES.map((data) => (
-            <MiniStory key={data.id} {...data} />
+            <FixedWidthOnLargeScreen key={data.id}>
+              <MiniStory {...data} />
+            </FixedWidthOnLargeScreen>
           ))}
         </SportsStories>
       </SportsSection>
@@ -47,6 +51,7 @@ const SpecialtyStoryGrid = () => {
 const Wrapper = styled.div`
   display: grid;
   gap: 48px;
+  grid-template-columns: minmax(0, 1fr);
 `;
 
 const MarketsSection = styled.section``;
@@ -63,6 +68,17 @@ const SportsStories = styled.div`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 16px;
+
+  @media (${QUERIES.tabletAndUp}) {
+    display: flex;
+    overflow: auto;
+  }
+`;
+
+const FixedWidthOnLargeScreen = styled.div`
+  @media (${QUERIES.tabletAndUp}) {
+    min-width: 220px;
+  }
 `;
 
 export default SpecialtyStoryGrid;


### PR DESCRIPTION
Submission for [Exercise 4: Specialty story grid](https://github.com/VrsajkovIvan33/new-grid-times?tab=readme-ov-file#exercise-4-specialty-story-grid)

- Set up "World Famous" grid on market and sports.
- Turn sports into overflowing flex row on tablet+.
- Two columns in laptop+ with a divider in between.