### PR TITLE
Footer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -5,6 +5,8 @@ import MaxWidthWrapper from '../MaxWidthWrapper';
 
 import VisuallyHidden from '../VisuallyHidden';
 
+import { QUERIES } from '../../constants';
+
 const Footer = () => {
   return (
     <Wrapper>
@@ -144,6 +146,16 @@ const TopRow = styled.div`
   font-size: 0.875rem;
   border-bottom: 1px solid var(--color-gray-700);
   padding: 24px 0;
+
+  @media(${QUERIES.tabletAndUp}) {
+    flex-direction: row;
+    justify-content: center;
+    gap: 48px;
+  }
+
+  @media(${QUERIES.laptopAndUp}) {
+    justify-content: flex-end;
+  }
 `;
 
 const Social = styled.div`

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -182,6 +182,12 @@ const MainNavArea = styled.div`
   gap: 32px;
   padding: 32px 0 48px;
   text-align: center;
+
+  @media (${QUERIES.tabletAndUp}) {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    text-align: left;
+  }
 `;
 
 const MainNavHeading = styled.h2`

--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -208,6 +208,10 @@ const Subfooter = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  @media (${QUERIES.laptopAndUp}) {
+    align-items: flex-start;
+  }
 `;
 
 const Logo = styled.a`


### PR DESCRIPTION
Submission for [Exercise 5: Footer](https://github.com/VrsajkovIvan33/new-grid-times?tab=readme-ov-file#exercise-5-footer).

- Make top row a row for tablet+ and adjust alignment for laptop+.
- Turn main footer navigation into dynamic grid with `auto-fit` to ensure equal spacing when it's one row.
- Adjust alignment for sub-footer on laptop+.